### PR TITLE
Add support for local imports in hooks

### DIFF
--- a/cookiecutter/generate.py
+++ b/cookiecutter/generate.py
@@ -19,7 +19,11 @@ from cookiecutter.exceptions import (
     UndefinedVariableInTemplate,
 )
 from cookiecutter.find import find_template
-from cookiecutter.hooks import run_hook_from_repo_dir
+from cookiecutter.hooks import (
+    render_hooks,
+    run_hook_from_rendered_hooks_dir,
+    run_hook_from_repo_dir,
+)
 from cookiecutter.utils import (
     create_env_with_context,
     make_sure_path_exists,
@@ -338,9 +342,15 @@ def generate_files(
     # if rendering fails
     delete_project_on_failure = output_directory_created and not keep_project_on_failure
 
+    render_hooks(
+        repo_dir=repo_dir,
+        context=context,
+        keep_project_on_failure=keep_project_on_failure,
+    )
+
     if accept_hooks:
-        run_hook_from_repo_dir(
-            repo_dir, 'pre_gen_project', project_dir, context, delete_project_on_failure
+        run_hook_from_rendered_hooks_dir(
+            repo_dir, 'pre_gen_project', project_dir, delete_project_on_failure
         )
 
     with work_in(template_dir):
@@ -416,12 +426,8 @@ def generate_files(
                     raise UndefinedVariableInTemplate(msg, err, context) from err
 
     if accept_hooks:
-        run_hook_from_repo_dir(
-            repo_dir,
-            'post_gen_project',
-            project_dir,
-            context,
-            delete_project_on_failure,
+        run_hook_from_rendered_hooks_dir(
+            repo_dir, 'post_gen_project', project_dir, delete_project_on_failure
         )
 
     return project_dir

--- a/cookiecutter/hooks.py
+++ b/cookiecutter/hooks.py
@@ -265,11 +265,14 @@ def render_hooks(repo_dir, context=None, keep_project_on_failure: bool = False) 
     output_dir = Path(rendered_hooks_dir.name)
 
     with work_in(hooks_dir):
+        pre_prompt_scripts = set(Path(f) for f in (find_hook('pre_prompt') or []))
         for root, dirs, files in os.walk('.'):
             for d in dirs:
                 make_sure_path_exists(Path(output_dir, root, d))
             for f in files:
                 infile = Path(root, f)
+                if infile in pre_prompt_scripts:
+                    continue
                 outfile = Path(output_dir, root, f)
                 logger.debug('Rendering file %s', infile)
 

--- a/cookiecutter/hooks.py
+++ b/cookiecutter/hooks.py
@@ -6,6 +6,7 @@ import os
 import subprocess  # nosec
 import sys
 import tempfile
+import warnings
 from collections import OrderedDict
 from pathlib import Path
 from typing import Dict, Union
@@ -160,6 +161,16 @@ def run_hook_from_repo_dir(
     :param delete_project_on_failure: Delete the project directory on hook
         failure?
     """
+    warnings.warn(
+        "The 'run_hook_from_repo_dir' function is deprecated, "
+        "and will be removed in a future release.\n"
+        "Use 'cookiecutter.hooks.run_hook_from_rendered_hooks_dir' "
+        "after rendering hooks with 'cookiecutter.hooks.render_hooks' "
+        "instead.",
+        DeprecationWarning,
+        2,
+    )
+
     with work_in(repo_dir):
         try:
             run_hook(hook_name, project_dir, context)

--- a/cookiecutter/hooks.py
+++ b/cookiecutter/hooks.py
@@ -6,15 +6,19 @@ import os
 import subprocess  # nosec
 import sys
 import tempfile
+from collections import OrderedDict
 from pathlib import Path
+from typing import Dict, Union
 
 from jinja2.exceptions import UndefinedError
 
 from cookiecutter import utils
 from cookiecutter.exceptions import FailedHookException
+from cookiecutter.generate import UndefinedVariableInTemplate
 from cookiecutter.utils import (
     create_env_with_context,
     create_tmp_repo_dir,
+    make_sure_path_exists,
     rmtree,
     work_in,
 )
@@ -27,6 +31,10 @@ _HOOKS = [
     'post_gen_project',
 ]
 EXIT_SUCCESS = 0
+
+hook_directories_for_repos: Dict[
+    Union[str, os.PathLike], tempfile.TemporaryDirectory
+] = {}
 
 
 def valid_hook(hook_file, hook_name):
@@ -169,6 +177,40 @@ def run_hook_from_repo_dir(
             raise
 
 
+def run_hook_from_rendered_hooks_dir(
+    repo_dir, hook_name, project_dir, delete_project_on_failure
+):
+    """
+    Try to find and execute a hook from the specified project directory.
+
+    :param repo_dir: Project template input directory.
+    :param hook_name: The hook to execute.
+    :param project_dir: The directory to execute the script from.
+    :param delete_project_on_failure: Delete the project directory on hook
+        failure?
+    """
+    hooks_temp_directory = hook_directories_for_repos.get(repo_dir)
+    if not hooks_temp_directory:
+        return None
+
+    scripts = find_hook(hook_name, hooks_dir=hooks_temp_directory.name)
+    if not scripts:
+        logger.debug('No %s hook found', hook_name)
+        return
+    logger.debug('Running hook %s', hook_name)
+    try:
+        for script in scripts:
+            run_script(script, project_dir)
+    except FailedHookException:
+        if delete_project_on_failure:
+            rmtree(project_dir)
+        logger.error(
+            "Stopping generation because %s hook " "script didn't exit successfully",
+            hook_name,
+        )
+        raise
+
+
 def run_pre_prompt_hook(repo_dir: "os.PathLike[str]") -> Path:
     """Run pre_prompt hook from repo directory.
 
@@ -190,3 +232,45 @@ def run_pre_prompt_hook(repo_dir: "os.PathLike[str]") -> Path:
             except FailedHookException:
                 raise FailedHookException('Pre-Prompt Hook script failed')
     return repo_dir
+
+
+def render_hooks(repo_dir, context=None, keep_project_on_failure: bool = False) -> None:
+    """Render the whole hooks directory to a temporary directory.
+
+    :param repo_dir: Project template input directory.
+    :param context: Cookiecutter project context.
+    :param keep_project_on_failure: Keep the generated project directory even when
+        generation fails
+    """
+    hooks_dir = Path(repo_dir, 'hooks')
+    if not hooks_dir.exists():
+        return None
+
+    context = context or OrderedDict([])
+    env = create_env_with_context(context)
+
+    rendered_hooks_dir = tempfile.TemporaryDirectory()
+    logger.debug("Creating temp folder for hooks in %s", rendered_hooks_dir.name)
+    output_dir = Path(rendered_hooks_dir.name)
+
+    with work_in(hooks_dir):
+        for root, dirs, files in os.walk('.'):
+            for d in dirs:
+                make_sure_path_exists(Path(output_dir, root, d))
+            for f in files:
+                infile = Path(root, f)
+                outfile = Path(output_dir, root, f)
+                logger.debug('Rendering file %s', infile)
+
+                template = env.from_string(infile.read_text(encoding='utf-8'))
+                try:
+                    output = template.render(**context)
+                except UndefinedError as err:
+                    if not keep_project_on_failure:
+                        rendered_hooks_dir.cleanup()
+                    msg = f"Unable to create file '{infile}'"
+                    raise UndefinedVariableInTemplate(msg, err, context) from err
+
+                outfile.write_text(output, encoding='utf-8')
+
+    hook_directories_for_repos[repo_dir] = rendered_hooks_dir


### PR DESCRIPTION
Render the whole hook directory to temp folder before executing hooks so it's possible to use local imports in hooks.

I kindly ask comments regarding this implementation before finalizing this PR by adding tests and documentation.

Few notes about the implementation:
- Pre_prompt_hook is still executed from the original location.
- Relative imports in hooks are not supported. This is because relative imports are not possible if the hook module itself is not imported. Hooks are executed as scripts Absolute imports should work inside the hook directory also without adding .
- Also all other files for example some utils modules are rendered.

Few questions that I have:
- How much we care about the backwards compatibility of the api? This leaves the following methods orphan:
  - `run_hook_from_repo_dir()`
  - `run_hook()`
  - `run_script_with_context()`
- Should it be possible modify the post_gen_hook by the pre_gen_hook?
- Should repo directory to be added to the sys.path?
